### PR TITLE
feat: Adds HLS Livestream URL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,6 +31,8 @@ CHURCH_ONLINE:
   URL: https://live.newspring.cc/api/v1/
   MEDIA_URLS: []
   WEB_VIEW_URL: https://live.newspring.cc
+LIVING_AS_ONE:
+  STREAM_URL: https://control.livingasone.com/ns/Manifest.m3u8
 ALGOLIA:
   APPLICATION_ID: ${ALGOLIA_APP_ID}
   API_KEY: ${ALGOLIA_API_KEY}

--- a/src/data/live/data-source.js
+++ b/src/data/live/data-source.js
@@ -2,7 +2,7 @@
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 import ApollosConfig from '@apollosproject/config';
 
-const { CHURCH_ONLINE, ROCK_MAPPINGS } = ApollosConfig;
+const { CHURCH_ONLINE, ROCK_MAPPINGS, LIVING_AS_ONE } = ApollosConfig;
 
 export default class LiveStream extends RockApolloDataSource {
   async getLiveStream() {
@@ -14,7 +14,7 @@ export default class LiveStream extends RockApolloDataSource {
     return {
       isLive: stream,
       eventStartTime: null,
-      media: () => null,
+      media: { sources: [{ uri: LIVING_AS_ONE.STREAM_URL }] },
       webViewUrl: CHURCH_ONLINE.WEB_VIEW_URL,
     };
   }


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-03-16 at 12 45 13 PM](https://user-images.githubusercontent.com/2659478/76781011-6705d180-6784-11ea-9c30-d27893e35cc9.png)


### What does this PR do, or why is it needed?

Sends the Living as one live stream URL to the app to use in the native player.

### How do I test this PR?

Start a schedule on alpha (I've already changed the sunday 9:15 to run until march 16th at 2pm) and run this query:

```
query getLiveContent {
  liveStreams {
    ...LiveStreamFragment
    __typename
  }
}

fragment LiveStreamFragment on LiveStream {
  isLive
  eventStartTime
  media {
    sources {
      uri
      __typename
    }
    __typename
  }
  webViewUrl
  contentItem {
    ... on WeekendContentItem {
      id
      __typename
    }
    __typename
  }
  __typename
}
```

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._