### PR TITLE
fix: Fixes Wistia Videos

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -81,6 +81,9 @@ CLOUDINARY:
 ENGINE:
   API_KEY: ${ENGINE_API_KEY}
   SCHEMA_TAG: ${ENGINE_SCHEMA_TAG}
+WISTIA:
+  API_URL: https://api.wistia.com/v1/medias
+  API_KEY: ${WISTIA_API_KEY}
 
 # This key holds various properties that allow our GraphQL server to map to your Rock Instance
 ROCK_MAPPINGS:

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -6,7 +6,7 @@ import sanitizeHtmlNode from 'sanitize-html';
 import Color from 'color';
 import { createAssetUrl } from '../utils';
 
-const { ROCK, ROCK_CONSTANTS } = ApollosConfig;
+const { ROCK, ROCK_CONSTANTS, WISTIA } = ApollosConfig;
 
 export default class ContentItem extends oldContentItem.dataSource {
   getContentItemScriptures = async ({ value: matrixItemGuid }) => {
@@ -36,14 +36,13 @@ export default class ContentItem extends oldContentItem.dataSource {
   };
 
   getWistiaAssetUrls = async (wistiaHashedId) => {
-    const videoData = await this.request('WistiaMedias')
-      .filter(`WistiaHashedId eq '${wistiaHashedId}'`)
-      .select('MediaData')
-      .get();
+    const media = await this.request(
+      `${WISTIA.API_URL}/${wistiaHashedId}.json?access_token=${WISTIA.API_KEY}`
+    ).get();
 
     const assetUrls = { video: '', thumbnail: '' };
-    if (!videoData.length) return assetUrls;
-    JSON.parse(videoData[0].mediaData).assets.forEach((asset) => {
+    if (!media) return assetUrls;
+    media.assets.forEach((asset) => {
       if (asset.type === 'HlsVideoFile' && asset.height === 720)
         assetUrls.video = asset.url.replace('.bin', '.m3u8');
       else if (asset.type === 'IphoneVideoFile')

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -39,8 +39,8 @@ export default class ContentItem extends oldContentItem.dataSource {
     const media = await this.request(
       `${WISTIA.API_URL}/${wistiaHashedId}.json?access_token=${WISTIA.API_KEY}`
     ).get();
-
     const assetUrls = { video: '', thumbnail: '' };
+
     if (!media) return assetUrls;
     media.assets.forEach((asset) => {
       if (asset.type === 'HlsVideoFile' && asset.height === 720)
@@ -118,18 +118,18 @@ export default class ContentItem extends oldContentItem.dataSource {
 
     return Promise.all(
       videoKeys.map(async (key) => {
-        const urls = await this.getWistiaAssetUrls(attributeValues[key].value);
+        let urls = {};
+        if (attributeValues[key].value)
+          urls = await this.getWistiaAssetUrls(attributeValues[key].value);
         return {
           __typename: 'VideoMedia',
           key,
           name: attributes[key].name,
           embedHtml: get(attributeValues, 'videoEmbed.value', null),
-          sources: attributeValues[key].value ? [{ uri: urls.video }] : [],
+          sources: urls.video ? [{ uri: urls.video }] : [],
           thumbnail: {
             __typename: 'ImageMedia',
-            sources: attributeValues[key].value
-              ? [{ uri: urls.thumbnail }]
-              : [],
+            sources: urls.thumbnail ? [{ uri: urls.thumbnail }] : [],
           },
         };
       })


### PR DESCRIPTION
## DESCRIPTION

<img width="1246" alt="Screen Shot 2020-03-17 at 10 54 50 PM" src="https://user-images.githubusercontent.com/2659478/76920819-d245c580-68a2-11ea-8cf6-a41c3e13a239.png">


### What does this PR do, or why is it needed?

Pulls video URLs from Wistia directly instead of Rock.

### How do I test this PR?

```
{
  node(id: "MediaContentItem:2b10cc5a2c62fcc1c327ac2672343875") {
    ... on MediaContentItem {
      videos {
        sources {
          uri
        }
      }
    }
  }
}
```

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._