### PR TITLE
feat: API Ready for Answered Prayer

### DIFF
--- a/src/data/prayers/data-source.js
+++ b/src/data/prayers/data-source.js
@@ -10,10 +10,7 @@ export default class Prayer extends RockApolloDataSource {
 
   expanded = true;
 
-  getFromId = (id) =>
-    this.request()
-      .find(id)
-      .get();
+  getFromId = (id) => this.request().find(id).get();
 
   sortPrayers = (prayers) =>
     prayers.sort((a, b) => {
@@ -63,9 +60,7 @@ export default class Prayer extends RockApolloDataSource {
       entityTypeId,
     });
     return RockConstants.createOrFindInteractionComponent({
-      componentName: `${
-        ROCK_MAPPINGS.INTERACTIONS.PRAYER_REQUEST
-      } - ${prayerId}`,
+      componentName: `${ROCK_MAPPINGS.INTERACTIONS.PRAYER_REQUEST} - ${prayerId}`,
       channelId: channel.id,
       entityId: parseInt(prayerId, 10),
     });
@@ -161,15 +156,22 @@ export default class Prayer extends RockApolloDataSource {
       .andFilter(`IsActive eq true`)
       .andFilter(`IsApproved eq true`)
       .andFilter(
-        `ExpirationDate gt datetime'${moment
-          .tz(ROCK.TIMEZONE)
-          .format()}' or ExpirationDate eq null`
+        type !== 'USER'
+          ? `ExpirationDate gt datetime'${moment
+              .tz(ROCK.TIMEZONE)
+              .format()}' or ExpirationDate eq null`
+          : ''
       )
+      .andFilter(type !== 'USER' ? `Answer eq null or Answer eq ''` : '')
       .andFilter(type === 'CAMPUS' ? `CampusId eq ${primaryCampusId}` : '')
-      .sort([
-        { field: 'PrayerCount', direction: 'asc' },
-        { field: 'EnteredDateTime', direction: 'asc' },
-      ]);
+      .sort(
+        type === 'USER'
+          ? [{ field: 'EnteredDateTime', direction: 'desc' }]
+          : [
+              { field: 'PrayerCount', direction: 'asc' },
+              { field: 'EnteredDateTime', direction: 'asc' },
+            ]
+      );
   };
 
   // deprecated
@@ -276,16 +278,9 @@ export default class Prayer extends RockApolloDataSource {
         IsActive: true,
         AllowComments: false,
         IsUrgent: false,
-        EnteredDateTime: moment()
-          .tz(ROCK.TIMEZONE)
-          .format(),
-        ApprovedOnDateTime: moment()
-          .tz(ROCK.TIMEZONE)
-          .format(),
-        ExpirationDate: moment()
-          .tz(ROCK.TIMEZONE)
-          .add(2, 'weeks')
-          .format(),
+        EnteredDateTime: moment().tz(ROCK.TIMEZONE).format(),
+        ApprovedOnDateTime: moment().tz(ROCK.TIMEZONE).format(),
+        ExpirationDate: moment().tz(ROCK.TIMEZONE).add(2, 'weeks').format(),
       });
       return this.getFromId(prayerId);
     } catch (e) {

--- a/src/data/prayers/data-source.js
+++ b/src/data/prayers/data-source.js
@@ -10,7 +10,10 @@ export default class Prayer extends RockApolloDataSource {
 
   expanded = true;
 
-  getFromId = (id) => this.request().find(id).get();
+  getFromId = (id) =>
+    this.request()
+      .find(id)
+      .get();
 
   sortPrayers = (prayers) =>
     prayers.sort((a, b) => {
@@ -60,7 +63,9 @@ export default class Prayer extends RockApolloDataSource {
       entityTypeId,
     });
     return RockConstants.createOrFindInteractionComponent({
-      componentName: `${ROCK_MAPPINGS.INTERACTIONS.PRAYER_REQUEST} - ${prayerId}`,
+      componentName: `${
+        ROCK_MAPPINGS.INTERACTIONS.PRAYER_REQUEST
+      } - ${prayerId}`,
       channelId: channel.id,
       entityId: parseInt(prayerId, 10),
     });
@@ -278,9 +283,16 @@ export default class Prayer extends RockApolloDataSource {
         IsActive: true,
         AllowComments: false,
         IsUrgent: false,
-        EnteredDateTime: moment().tz(ROCK.TIMEZONE).format(),
-        ApprovedOnDateTime: moment().tz(ROCK.TIMEZONE).format(),
-        ExpirationDate: moment().tz(ROCK.TIMEZONE).add(2, 'weeks').format(),
+        EnteredDateTime: moment()
+          .tz(ROCK.TIMEZONE)
+          .format(),
+        ApprovedOnDateTime: moment()
+          .tz(ROCK.TIMEZONE)
+          .format(),
+        ExpirationDate: moment()
+          .tz(ROCK.TIMEZONE)
+          .add(2, 'weeks')
+          .format(),
       });
       return this.getFromId(prayerId);
     } catch (e) {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR:
* No longer filters out expired prayers when looking at user prayers.
* Sorts user prayers by newest first.
* Removes answered prayers from the prayer feed.

### How do I test this PR?
* Make sure there are 2 prayers that could potentially show up in your `My Church` feed. One that has an answer and one that doesn't. Run the `prayerFeed` query for `My Church` and you should only see the prayer that doesn't have the answer.
* Run the `prayerFeed` query using `USER` as the type. You should see all of the prayers you've entered in order by newest first.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
