### PR TITLE
fix: Write empty string to remove answer

### DIFF
--- a/src/data/prayers/resolver.js
+++ b/src/data/prayers/resolver.js
@@ -64,7 +64,7 @@ export default {
           });
           return Node.get(id, dataSources, info);
         case 'REMOVE_ANSWER':
-          return dataSources.Prayer.answer(rockID, null);
+          return dataSources.Prayer.answer(rockID, '');
         default:
           return null;
       }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR just updates the `REMOVE_ANSWER` resolver function to pass an empty string instead of `null` since that is more correct.

### How do I test this PR?
Just make sure everything works like it should. Nothing should be different.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
