### PR TITLE
fix: Figures out correct series siblings

### DIFF
--- a/src/data/content-items/resolver.js
+++ b/src/data/content-items/resolver.js
@@ -79,6 +79,19 @@ const resolver = {
         ),
       };
     },
+    siblingContentItemsConnection: async ({ id }, args, { dataSources }) => {
+      const series = await dataSources.ContentItem.getSeries(
+        id,
+        ROCK_MAPPINGS.DEVOTIONAL_SERIES_CHANNEL_ID
+      );
+      const cursor = await dataSources.ContentItem.getCursorByParentContentItemId(
+        series.id
+      );
+      return dataSources.ContentItem.paginate({
+        cursor,
+        args,
+      });
+    },
   },
   WeekendContentItem: {
     ...defaultResolvers,
@@ -136,6 +149,19 @@ const resolver = {
           startDateTime
         ),
       };
+    },
+    siblingContentItemsConnection: async ({ id }, args, { dataSources }) => {
+      const series = await dataSources.ContentItem.getSeries(
+        id,
+        ROCK_MAPPINGS.SERMON_SERIES_CHANNEL_ID
+      );
+      const cursor = await dataSources.ContentItem.getCursorByParentContentItemId(
+        series.id
+      );
+      return dataSources.ContentItem.paginate({
+        cursor,
+        args,
+      });
     },
     sermonNotes: (
       { id, attributeValues: { sermonNotes } },


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Gets the correct siblings and ignores from any parent outside the series

### How do I test this PR?

```
{
  node(id: "WeekendContentItem:8d5de4f28f2a0ea47d3087476af0a2e2") {
    ... on WeekendContentItem {
      seriesConnection {
        series {
          title
        }
      }
      title
      siblingContentItemsConnection {
        edges {
          node {
            title
            ... on WeekendContentItem {
              seriesConnection {
                series {
                  title
                }
              }
            }
          }
        }
      }
    }
  }
}
```

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings
- [ ] Upload Screenshots/GIF(s) if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._