### PR TITLE
fix: Prayer notification interaction correctly created for new prayers

### DIFF
--- a/src/data/prayers/__tests__/__snapshots__/data-source.test.js.snap
+++ b/src/data/prayers/__tests__/__snapshots__/data-source.test.js.snap
@@ -7,6 +7,10 @@ Object {
 }
 `;
 
+exports[`PrayerRequest data sources creates a prayer interaction 1`] = `undefined`;
+
+exports[`PrayerRequest data sources creates an initial prayer interaction 1`] = `undefined`;
+
 exports[`PrayerRequest data sources gets an empty list of saved prayers 1`] = `Array []`;
 
 exports[`PrayerRequest data sources gets an empty list of saved prayers 2`] = `0`;

--- a/src/data/prayers/__tests__/data-source.test.js
+++ b/src/data/prayers/__tests__/data-source.test.js
@@ -55,4 +55,26 @@ describe('PrayerRequest data sources', () => {
     Prayer.getFromId = () => ({ id: 1, answer: '' });
     expect(await Prayer.answer(1, null)).toMatchSnapshot();
   });
+  it('creates an initial prayer interaction', async () => {
+    Prayer.context.dataSources.Auth = {
+      getCurrentPerson: () => ({ id: 'Person123' }),
+    };
+    Prayer.post = () => ({
+      result: '',
+    });
+    Prayer.fetch = () => jest.fn();
+    Prayer.getInteractionComponent = () => ({ id: 1 });
+    expect(await Prayer.createInteraction(123456)).toMatchSnapshot();
+  });
+  it('creates a prayer interaction', async () => {
+    Prayer.context.dataSources.Auth = {
+      getCurrentPerson: () => ({ id: 'Person123' }),
+    };
+    Prayer.post = () => ({
+      result: '12-31-2019 01:01:01AM',
+    });
+    Prayer.fetch = () => jest.fn();
+    Prayer.getInteractionComponent = () => ({ id: 1 });
+    expect(await Prayer.createInteraction(123456)).toMatchSnapshot();
+  });
 });

--- a/src/data/prayers/__tests__/data-source.test.js
+++ b/src/data/prayers/__tests__/data-source.test.js
@@ -59,9 +59,7 @@ describe('PrayerRequest data sources', () => {
     Prayer.context.dataSources.Auth = {
       getCurrentPerson: () => ({ id: 'Person123' }),
     };
-    Prayer.post = () => ({
-      result: '',
-    });
+    Prayer.post = () => '';
     Prayer.fetch = () => jest.fn();
     Prayer.getInteractionComponent = () => ({ id: 1 });
     expect(await Prayer.createInteraction(123456)).toMatchSnapshot();
@@ -70,9 +68,7 @@ describe('PrayerRequest data sources', () => {
     Prayer.context.dataSources.Auth = {
       getCurrentPerson: () => ({ id: 'Person123' }),
     };
-    Prayer.post = () => ({
-      result: '12-31-2019 01:01:01AM',
-    });
+    Prayer.post = () => '12-31-2019 01:01:01AM';
     Prayer.fetch = () => jest.fn();
     Prayer.getInteractionComponent = () => ({ id: 1 });
     expect(await Prayer.createInteraction(123456)).toMatchSnapshot();

--- a/src/data/prayers/data-source.js
+++ b/src/data/prayers/data-source.js
@@ -98,6 +98,7 @@ export default class Prayer extends RockApolloDataSource {
         {% endsql %}{% for result in results %}{{ result.InteractionDateTime }}{% endfor %}`
       );
       summary =
+        result === '' ||
         moment(result, 'MM/DD/YYYY HH:mm:ss a').add(2, 'hours') < moment()
           ? 'PrayerNotificationSent'
           : '';


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR adds a check to the `summary` calculation so that if the `result` of the check to see the last time that a prayer notification comes back empty (meaning it has never had a prayer notification interaction) then set the summary correctly so that a prayer notification is triggered.

That `RenderTemplate` API endpoint returns "" if it cannot find an interaction with a summary of "PrayerNotificationSent" for a particular prayer. When this happens, the call to `moment` to get 2 hours back fails, so the summary is never set to "PrayerNotificationSent" and the prayer never gets a notification. 

This change makes it so that if the `result === ''` then we automatically set the summary to "PrayerNotificationSent" so that the prayer gets a notification.

** NOTE **: Also this looks like it might be a fix of the prayer interaction time discrepancy as well. When I test from the app on my phone I get the 4 hour difference in time but when I test from this branch the times are correct.
 
### How do I test this PR?
Pray for a brand new prayer and make sure that a prayer interaction with a summary of "PrayerNotificationSent" is correctly created.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
