### PR TITLE
chore: Set Default Bible Translation for Sermon Notes

### DIFF
--- a/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -41,6 +41,17 @@ Array [
     },
     "simpleText": "verse Genesis 1:1",
   },
+  Object {
+    "__typename": "NotesScriptureBlock",
+    "allowsComment": true,
+    "comment": null,
+    "id": "NotesScriptureBlock:a0f64573eabf00a607bec911794d50fb",
+    "scripture": Object {
+      "content": "<p>verse<p>",
+      "reference": "Genesis 1:1",
+    },
+    "simpleText": "verse Genesis 1:1",
+  },
 ]
 `;
 

--- a/src/data/content-items/__tests__/data-source.tests.js
+++ b/src/data/content-items/__tests__/data-source.tests.js
@@ -1,5 +1,17 @@
+import ApollosConfig from '@apollosproject/config';
 import personMock from '../../mocks/person';
 import ContentDataSource from '../data-source';
+
+ApollosConfig.loadJs({
+  BIBLE_API: {
+    BIBLE_ID: {
+      ESV: 'f421fe261da7624f-01',
+      NIV: '71c6eab17ae5b667-01',
+      CSB: 'a556c5305ee15c3f-01',
+      WEB: '9879dbb7cfe39e4d-01',
+    },
+  },
+});
 
 describe('ContentItem data sources', () => {
   let ContentItem;
@@ -79,6 +91,17 @@ describe('ContentItem data sources', () => {
             book: { value: '1234-234-234' },
             reference: { value: '3:5-6' },
             translation: { value: '23423-23423-23423' },
+            allowsComment: { value: 'True' },
+          },
+        },
+        {
+          id: 4,
+          attributeValues: {
+            noteType: { value: 'scripture' },
+            text: { value: '' },
+            book: { value: 'John' },
+            reference: { value: '3:16' },
+            translation: { value: '' },
             allowsComment: { value: 'True' },
           },
         },

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -419,7 +419,9 @@ export default class ContentItem extends oldContentItem.dataSource {
         Text: data,
         CreatedByPersonAliasId: primaryAliasId,
       });
-    const note = await this.request('Notes').find(rockNoteID).get();
+    const note = await this.request('Notes')
+      .find(rockNoteID)
+      .get();
     return {
       id: createGlobalId(note.id, 'NotesBlockComment'),
       text,

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -6,7 +6,13 @@ import sanitizeHtmlNode from 'sanitize-html';
 import Color from 'color';
 import { createAssetUrl } from '../utils';
 
-const { ROCK, ROCK_CONSTANTS, ROCK_MAPPINGS, WISTIA } = ApollosConfig;
+const {
+  ROCK,
+  ROCK_CONSTANTS,
+  ROCK_MAPPINGS,
+  WISTIA,
+  BIBLE_API,
+} = ApollosConfig;
 
 export default class ContentItem extends oldContentItem.dataSource {
   getContentItemScriptures = async ({ value: matrixItemGuid }) => {
@@ -413,9 +419,7 @@ export default class ContentItem extends oldContentItem.dataSource {
         Text: data,
         CreatedByPersonAliasId: primaryAliasId,
       });
-    const note = await this.request('Notes')
-      .find(rockNoteID)
-      .get();
+    const note = await this.request('Notes').find(rockNoteID).get();
     return {
       id: createGlobalId(note.id, 'NotesBlockComment'),
       text,
@@ -461,12 +465,19 @@ export default class ContentItem extends oldContentItem.dataSource {
                 isHeader: type === 'header',
               };
             case 'scripture':
-              book = await this.request('/DefinedValues')
+              book = await this.request('DefinedValues')
                 .filter(`Guid eq guid'${bookGUID}'`)
                 .first();
-              version = await this.request('/DefinedValues')
-                .filter(`Guid eq guid'${versionGUID}'`)
-                .first();
+              if (versionGUID === '') {
+                const versionName = Object.keys(BIBLE_API.BIBLE_ID)[0];
+                version = await this.request('DefinedValues')
+                  .filter(`Value eq '${versionName}'`)
+                  .first();
+              } else {
+                version = await this.request('DefinedValues')
+                  .filter(`Guid eq guid'${versionGUID}'`)
+                  .first();
+              }
               scriptures = await Scripture.getScriptures(
                 `${book.value} ${ref}`,
                 version.value


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR sets a default Bible translation for sermon notes. If someone forgets to set a translation in the matrix item it will be defaulted to whatever is the first in the list in our `config.yml`.

![Screenshot 2020-06-22 10 52 53](https://user-images.githubusercontent.com/3229463/85303028-f56eab00-b477-11ea-8adf-af06062aef32.png)

### How do I test this PR?
Set a sermon scripture note to not have a translation (or just look at the _My House God's Plan_ sermon on `alpha-rock`) and make sure that the scripture note returns whatever version you have first in your config.

In the screenshot above, you can see that there are 2 of the same scripture. The NIV version is the one that is set in the matrix item and the ESV version is not (so it's the default).

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
