### PR TITLE
fix: Fixes Devotional Bible References to Multiple Books

### DIFF
--- a/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -55,6 +55,16 @@ Array [
     },
     "simpleText": "verse Genesis 1:1",
   },
+  Object {
+    "__typename": "NotesTextBlock",
+    "allowsComment": true,
+    "comment": null,
+    "hasBlanks": true,
+    "hiddenText": "this is another ________",
+    "id": "NotesTextBlock:772fcb6087247ebad630814e2ce0cd16",
+    "isHeader": false,
+    "simpleText": "this is another subpoint",
+  },
 ]
 `;
 

--- a/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -3,7 +3,10 @@
 exports[`ContentItem data sources gets scripture references 1`] = `
 Array [
   Array [
-    "john 1:1, 10:10",
+    "john 10:10",
+  ],
+  Array [
+    "john 1:1",
   ],
 ]
 `;

--- a/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/src/data/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -39,10 +39,10 @@ Array [
     "comment": null,
     "id": "NotesScriptureBlock:4f68015ba18662a7409d1219a4ce013e",
     "scripture": Object {
-      "content": "<p>verse<p>",
+      "content": "<p>1 In the beginning...<p>",
       "reference": "Genesis 1:1",
     },
-    "simpleText": "verse Genesis 1:1",
+    "simpleText": "1)  In the beginning... Genesis 1:1",
   },
   Object {
     "__typename": "NotesScriptureBlock",
@@ -50,10 +50,10 @@ Array [
     "comment": null,
     "id": "NotesScriptureBlock:a0f64573eabf00a607bec911794d50fb",
     "scripture": Object {
-      "content": "<p>verse<p>",
+      "content": "<p>1 In the beginning...<p>",
       "reference": "Genesis 1:1",
     },
-    "simpleText": "verse Genesis 1:1",
+    "simpleText": "1)  In the beginning... Genesis 1:1",
   },
   Object {
     "__typename": "NotesTextBlock",

--- a/src/data/content-items/__tests__/data-source.tests.js
+++ b/src/data/content-items/__tests__/data-source.tests.js
@@ -116,6 +116,17 @@ describe('ContentItem data sources', () => {
             allowsComment: { value: 'True' },
           },
         },
+        {
+          id: 6,
+          attributeValues: {
+            noteType: { value: 'invalid' },
+            text: { value: '' },
+            book: { value: '' },
+            reference: { value: '' },
+            translation: { value: '' },
+            allowsComment: { value: 'True' },
+          },
+        },
       ],
     };
     ContentItem.request = () => ({
@@ -123,7 +134,7 @@ describe('ContentItem data sources', () => {
     });
     ContentItem.context.dataSources.Scripture = {
       getScriptures: () => [
-        { content: '<p>verse<p>', reference: 'Genesis 1:1' },
+        { content: '<p>1 In the beginning...<p>', reference: 'Genesis 1:1' },
       ],
     };
     ContentItem.getNotesComments = () => ({

--- a/src/data/content-items/__tests__/data-source.tests.js
+++ b/src/data/content-items/__tests__/data-source.tests.js
@@ -105,6 +105,17 @@ describe('ContentItem data sources', () => {
             allowsComment: { value: 'True' },
           },
         },
+        {
+          id: 5,
+          attributeValues: {
+            noteType: { value: 'text' },
+            text: { value: 'this is another __subpoint__' },
+            book: { value: '' },
+            reference: { value: '' },
+            translation: { value: '' },
+            allowsComment: { value: 'True' },
+          },
+        },
       ],
     };
     ContentItem.request = () => ({

--- a/src/data/content-items/__tests__/data-source.tests.js
+++ b/src/data/content-items/__tests__/data-source.tests.js
@@ -26,7 +26,7 @@ describe('ContentItem data sources', () => {
   it('gets scripture references', async () => {
     ContentItem.context = {
       dataSources: {
-        Scripture: { getScriptures: jest.fn(() => null) },
+        Scripture: { getScriptures: jest.fn(() => []) },
         MatrixItem: {
           getItemsFromGuid: () =>
             Promise.resolve([

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -491,6 +491,6 @@ export default class ContentItem extends oldContentItem.dataSource {
         }
       )
     );
-    return notes;
+    return notes.filter((note) => note !== null);
   };
 }


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-06-30 at 8 51 57 AM](https://user-images.githubusercontent.com/2659478/86128864-ea3b0100-baaf-11ea-83ea-e220356fe916.png)


### What does this PR do, or why is it needed?

Fixes calls to scripture references with multiple books by breaking up calls the Bible.API.

### How do I test this PR?

Click through the app and make sure devos look ok. You can run this query to check the one that was causing the error in the first place.

```
{
  node(id: "DevotionalContentItem:03d2fa84f492463b75a3bc87886cb5a4") {
    ... on DevotionalContentItem {
      title
      scriptures {
        reference
      }
    }
  }
}
```

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._