### PR TITLE
chore: Added Prayer Query

### DIFF
--- a/src/data/prayers/__tests__/__snapshots__/resolver.test.js.snap
+++ b/src/data/prayers/__tests__/__snapshots__/resolver.test.js.snap
@@ -67,6 +67,17 @@ Object {
 }
 `;
 
+exports[`Prayer resolver gets a prayer 1`] = `
+Object {
+  "data": Object {
+    "prayer": Object {
+      "id": "Prayer:559b23fd0aa90e81b1c023e72e230fa1",
+      "text": "very serious prayer",
+    },
+  },
+}
+`;
+
 exports[`Prayer resolver gets a prayer feed 1`] = `
 Object {
   "data": Object {

--- a/src/data/prayers/__tests__/resolver.test.js
+++ b/src/data/prayers/__tests__/resolver.test.js
@@ -49,6 +49,23 @@ describe('Prayer resolver', () => {
     rootValue = {};
   });
 
+  it('gets a prayer', async () => {
+    const query = `
+      query {
+        prayer(id: 1) {
+          id
+          text
+        }
+      }
+    `;
+
+    context.dataSources.Prayer.getFromId = jest.fn(() =>
+      Promise.resolve({ id: 1, text: 'very serious prayer' })
+    );
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+  });
+
   it('gets a prayer feed', async () => {
     const query = `
       query {
@@ -177,6 +194,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('gets all saved prayers', async () => {
     const query = `
       query {
@@ -212,6 +230,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('answers a prayer', async () => {
     const query = `
       mutation {
@@ -231,6 +250,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('removes a prayer answer', async () => {
     const query = `
       mutation {
@@ -250,6 +270,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('deletes a prayer (deprecated)', async () => {
     const query = `
       mutation {
@@ -286,6 +307,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('increments prayed for a request (deprecated)', async () => {
     const query = `
       mutation {
@@ -324,6 +346,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('flags a prayer request (deprecated)', async () => {
     const query = `
       mutation {
@@ -339,6 +362,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('flags a prayer request', async () => {
     const query = `
       mutation {
@@ -357,6 +381,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('saves a prayer (deprecated)', async () => {
     const query = `
       mutation {
@@ -371,6 +396,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('saves a prayer', async () => {
     const query = `
       mutation {
@@ -388,6 +414,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('unsaves a prayer (deprecated)', async () => {
     const query = `
       mutation {
@@ -402,6 +429,7 @@ describe('Prayer resolver', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+
   it('unsaves a prayer', async () => {
     const query = `
       mutation {

--- a/src/data/prayers/resolver.js
+++ b/src/data/prayers/resolver.js
@@ -8,8 +8,8 @@ import { createAssetUrl } from '../utils';
 
 export default {
   Query: {
-    prayer: (root, { id }, { dataSources }) =>
-      dataSources.Prayer.getFromId(parseGlobalId(id).id),
+    // This takes a Rock ID, not a Node ID.
+    prayer: (root, { id }, { dataSources }) => dataSources.Prayer.getFromId(id),
     // deprecated
     prayers: (root, { type }, { dataSources }) =>
       dataSources.Prayer.getPrayers(type),

--- a/src/data/prayers/resolver.js
+++ b/src/data/prayers/resolver.js
@@ -8,6 +8,8 @@ import { createAssetUrl } from '../utils';
 
 export default {
   Query: {
+    prayer: (root, { id }, { dataSources }) =>
+      dataSources.Prayer.getFromId(parseGlobalId(id).id),
     // deprecated
     prayers: (root, { type }, { dataSources }) =>
       dataSources.Prayer.getPrayers(type),

--- a/src/data/prayers/schema.js
+++ b/src/data/prayers/schema.js
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 const prayerSchema = gql`
   extend type Query {
+    prayer(id: ID!): Prayer
     prayers(type: PrayerType): [Prayer]
       @deprecated(reason: "Use paginated version: prayerFeed")
     prayerFeed(first: Int, after: String, type: PrayerType): PrayersConnection


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR adds a query to return one prayer using it's Id.

### How do I test this PR?
Run this query:
```{
  prayer(id:780) {
    ...prayerFragment
  }
}

fragment prayerFragment on Prayer {
    __typename
    id
    isAnonymous
    isSaved
    text
    answer
    flagCount
    campus {
      id
      name
    }
    startTime
    requestor {
      photo {
        uri
      }
      firstName
      nickName
      lastName
    }
  }
```

You can replace the prayer id with any id you want. Just know it's a Rock Id. 

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload Screenshots/GIF(s) if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
