### PR TITLE
Fix content sort

### DIFF
--- a/src/data/action-algorithm/index.js
+++ b/src/data/action-algorithm/index.js
@@ -1,12 +1,54 @@
 import { ActionAlgorithm } from '@apollosproject/data-connector-rock';
+import ApollosConfig from '@apollosproject/config';
+import { get, flatten } from 'lodash';
 
 const { schema, resolver } = ActionAlgorithm;
 
 class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
+    CAMPAIGN_ITEMS: this.campaignItemsAlgorithm.bind(this),
     STAFF_NEWS: this.contentChannelAlgorithm.bind(this),
   };
+
+  async campaignItemsAlgorithm({ limit = 1 } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    const channels = await ContentItem.byContentChannelIds(
+      ApollosConfig.ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS
+    ).get();
+
+    const items = flatten(
+      await Promise.all(
+        channels.map(async ({ id, title }) => {
+          const childItemsCursor = await ContentItem.getCursorByParentContentItemId(
+            id
+          );
+
+          const childItems = await childItemsCursor
+            .orderBy('StartDateTime', 'desc') // Custom for newspring. We are ordering by startDateTime here.
+            .top(limit)
+            .expand('ContentChannel')
+            .get();
+
+          return childItems.map((item) => ({
+            ...item,
+            channelSubtitle: title,
+          }));
+        })
+      )
+    );
+
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: get(item, 'contentChannel.name'),
+      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
+      image: ContentItem.getCoverImage(item),
+      action: 'READ_CONTENT',
+      summary: ContentItem.createSummary(item),
+    }));
+  }
 }
 
 export { dataSource, schema, resolver };

--- a/src/data/content-items/__tests__/__snapshots__/resolvers.tests.js.snap
+++ b/src/data/content-items/__tests__/__snapshots__/resolvers.tests.js.snap
@@ -173,6 +173,32 @@ Object {
 }
 `;
 
+exports[`UniversalContentItem gets a newspring devotional item's siblings 1`] = `
+Object {
+  "data": Object {
+    "node": Object {
+      "id": "DevotionalContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+      "scriptures": Array [
+        Object {
+          "html": "<p><i>1</i>In the beginning...</p>",
+        },
+      ],
+      "siblingContentItemsConnection": Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "id": "UniversalContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+              "title": "SAMPLE: Easter",
+            },
+          },
+        ],
+      },
+      "title": "SAMPLE: Easter",
+    },
+  },
+}
+`;
+
 exports[`UniversalContentItem gets a newspring weekend content item 1`] = `
 Object {
   "data": Object {

--- a/src/data/content-items/__tests__/resolvers.tests.js
+++ b/src/data/content-items/__tests__/resolvers.tests.js
@@ -196,6 +196,33 @@ describe('UniversalContentItem', () => {
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
+  it("gets a newspring devotional item's siblings", async () => {
+    const query = `
+      query {
+        node(id: "${createGlobalId(123, 'DevotionalContentItem')}") {
+          id
+          ... on DevotionalContentItem {
+            id
+            title
+            scriptures {
+              html
+            }
+            siblingContentItemsConnection {
+              edges {
+                node {
+                  id
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    const rootValue = {};
+    const result = await graphql(schema, query, rootValue, context);
+    expect(result).toMatchSnapshot();
+  });
 
   it('gets a newspring weekend content item', async () => {
     const query = `

--- a/src/data/content-items/data-source.js
+++ b/src/data/content-items/data-source.js
@@ -23,24 +23,57 @@ export default class ContentItem extends oldContentItem.dataSource {
 
     if (!associations || !associations.length) return this.request().empty();
 
-    return this.getFromIds(
+    const cursor = this.getFromIds(
       associations.map(
         ({ childContentChannelItemId }) => childContentChannelItemId
       )
-    ).transform((results) =>
-      results.sort((a, b) => {
-        /**
-         * Find the Association Order for the given content channel items
-         */
-        const { order: orderA } = associations.find(
-          (item) => item.childContentChannelItemId === a.id
-        );
-        const { order: orderB } = associations.find(
-          (item) => item.childContentChannelItemId === b.id
-        );
-        return orderA - orderB;
-      })
     );
+    let sortByOrder = false;
+
+    // If this is true, our transform will be activated.
+    // The transform is the only wait to sort by `order`
+    const originalOrderBy = cursor.orderBy;
+
+    // Here we hijack the default behavior of the `.order` call, using it to set
+    // a value that we are going to use to trigger the `transform`
+    cursor.orderBy = (name, direction) => {
+      if (name === 'Order') {
+        sortByOrder = true;
+      }
+      // call is important here to preserve the original value of `this` (it should be `cursor`)
+      return originalOrderBy.call(cursor, name, direction);
+    };
+
+    // Same as above.
+    const originalSort = cursor.sort;
+    cursor.sort = (sorts) => {
+      if (sorts.map(({ field }) => field).includes('Order')) {
+        sortByOrder = true;
+      }
+      return originalSort.call(cursor, sorts);
+    };
+
+    cursor.transform((results) => {
+      // If we have called .orderBy or .sort w/ `order`, we do our in memory sort.
+      if (sortByOrder) {
+        return results.sort((a, b) => {
+          /**
+           * Find the Association Order for the given content channel items
+           */
+          const { order: orderA } = associations.find(
+            (item) => item.childContentChannelItemId === a.id
+          );
+          const { order: orderB } = associations.find(
+            (item) => item.childContentChannelItemId === b.id
+          );
+          return orderA - orderB;
+        });
+      }
+      return results;
+    });
+
+    // Return the cursor.
+    return cursor;
   };
 
   getContentItemScriptures = async ({ value: matrixItemGuid }) => {

--- a/src/data/content-items/resolver.js
+++ b/src/data/content-items/resolver.js
@@ -23,6 +23,8 @@ const defaultResolvers = {
     );
     if (ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS.includes(root.contentChannelId)) {
       cursor.orderBy('StartDateTime', 'desc');
+    } else {
+      cursor.orderBy('Order');
     }
     return dataSources.ContentItem.paginate({
       cursor,
@@ -101,7 +103,7 @@ const resolver = {
         series.id
       );
       return dataSources.ContentItem.paginate({
-        cursor,
+        cursor: cursor.orderBy('Order'),
         args,
       });
     },
@@ -172,7 +174,7 @@ const resolver = {
         series.id
       );
       return dataSources.ContentItem.paginate({
-        cursor,
+        cursor: cursor.orderBy('Order'),
         args,
       });
     },

--- a/src/data/features/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/src/data/features/__tests__/__snapshots__/data-source.tests.js.snap
@@ -33,3 +33,190 @@ Array [
   },
 ]
 `;
+
+exports[`Feature data sources should create an ActionListFeature from a CAMPAIGN_ITEMS algorithm 1`] = `
+Object {
+  "__typename": "ActionListFeature",
+  "actions": Array [
+    Object {
+      "action": "READ_CONTENT",
+      "id": "10",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "first item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 1,
+        "title": "first item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "first item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "21",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "first item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 2,
+        "title": "second item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "second item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "32",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "first item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 3,
+        "title": "third item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "third item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "13",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "second item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 1,
+        "title": "first item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "first item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "24",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "second item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 2,
+        "title": "second item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "second item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "35",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "second item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 3,
+        "title": "third item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "third item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "16",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "third item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 1,
+        "title": "first item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "first item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "27",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "third item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 2,
+        "title": "second item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "second item",
+    },
+    Object {
+      "action": "READ_CONTENT",
+      "id": "38",
+      "image": null,
+      "relatedNode": Object {
+        "__type": "UniversalContentItem",
+        "channelSubtitle": "third item",
+        "contentChannel": Object {
+          "name": "content channel",
+        },
+        "id": 3,
+        "title": "third item",
+      },
+      "subtitle": "content channel",
+      "summary": "some summary",
+      "title": "third item",
+    },
+  ],
+  "id": "{\\"algorithms\\":[{\\"type\\":\\"CAMPAIGN_ITEMS\\"}],\\"title\\":\\"Test Featured Item\\",\\"subtitle\\":\\"It's featured!\\"}",
+  "primaryAction": undefined,
+  "subtitle": "It's featured!",
+  "title": "Test Featured Item",
+}
+`;
+
+exports[`Feature data sources should create an ActionListFeature from a CAMPAIGN_ITEMS algorithm 2`] = `
+Array [
+  Array [
+    1,
+  ],
+  Array [
+    2,
+  ],
+  Array [
+    3,
+  ],
+]
+`;
+
+exports[`Feature data sources should create an ActionListFeature from a CAMPAIGN_ITEMS algorithm 3`] = `
+Array [
+  Array [
+    undefined,
+  ],
+]
+`;

--- a/src/data/features/__tests__/data-source.tests.js
+++ b/src/data/features/__tests__/data-source.tests.js
@@ -1,6 +1,25 @@
 import ApollosConfig from '@apollosproject/config';
 import { dataSource as FeatureDataSource } from '../index';
 import { dataSource as FeedDataSource } from '../../feature-feed';
+import { dataSource as ActionAlgorithm } from '../../action-algorithm';
+
+async function expandResult(result) {
+  let expandedResult = { ...result };
+  if (result.cards && typeof result.cards === 'function') {
+    expandedResult = { ...expandedResult, cards: await result.cards() };
+  }
+  if (result.actions && typeof result.actions === 'function') {
+    expandedResult = { ...expandedResult, actions: await result.actions() };
+  }
+  if (result.heroCard && typeof result.heroCard === 'function') {
+    expandedResult = { ...expandedResult, heroCard: await result.heroCard() };
+  }
+  if (result.prayers && typeof result.prayers === 'function') {
+    expandedResult = { ...expandedResult, prayers: await result.prayers() };
+  }
+
+  return expandedResult;
+}
 
 ApollosConfig.loadJs({
   HOME_FEATURES: [
@@ -20,18 +39,76 @@ ApollosConfig.loadJs({
 describe('Feature data sources', () => {
   let Feature;
   let FeatureFeed;
+  const getCursorByParentContentItemId = jest.fn(() => ({
+    orderBy: () => ({
+      top: () => ({
+        expand: () => ({
+          get: () => [
+            {
+              id: 1,
+              title: 'first item',
+              contentChannel: { name: 'content channel' },
+            },
+            {
+              id: 2,
+              title: 'second item',
+              contentChannel: { name: 'content channel' },
+            },
+            {
+              id: 3,
+              title: 'third item',
+              contentChannel: { name: 'content channel' },
+            },
+          ],
+        }),
+      }),
+    }),
+  }));
+  const byContentChannelIds = jest.fn(() => ({
+    get: () => [
+      {
+        id: 1,
+        title: 'first item',
+        contentChannel: { name: 'content channel' },
+      },
+      {
+        id: 2,
+        title: 'second item',
+        contentChannel: { name: 'content channel' },
+      },
+      {
+        id: 3,
+        title: 'third item',
+        contentChannel: { name: 'content channel' },
+      },
+    ],
+  }));
+  let context;
   beforeEach(() => {
+    const ActionAlgo = new ActionAlgorithm();
     Feature = new FeatureDataSource();
     FeatureFeed = new FeedDataSource();
-    FeatureFeed.context = { dataSources: {} };
-    FeatureFeed.context.dataSources = {
+    context = { dataSources: {} };
+    context.dataSources = {
       Auth: { getCurrentPerson: () => ({ id: 1 }) },
+      ActionAlgorithm: ActionAlgo,
+      Feature,
       Person: { isStaff: () => true },
       Group: {
         getTestGroups: () => [{ id: 1, name: 'Experimental Features' }],
       },
+      FeatureFeed,
+      ContentItem: {
+        getCursorByParentContentItemId,
+        byContentChannelIds,
+        resolveType: () => 'UniversalContentItem',
+        getCoverImage: () => null,
+        createSummary: () => 'some summary',
+      },
     };
-    Feature.context = { dataSources: { FeatureFeed } };
+    context.dataSources.ActionAlgorithm.initialize({ context });
+    context.dataSources.Feature.initialize({ context });
+    context.dataSources.FeatureFeed.initialize({ context });
   });
   it('gets available features', async () => {
     expect(await Feature.getHomeFeedFeatures()).toMatchSnapshot();
@@ -39,5 +116,24 @@ describe('Feature data sources', () => {
   it('gets available as non-staff', async () => {
     FeatureFeed.context.dataSources.Person.isStaff = () => false;
     expect(await Feature.getHomeFeedFeatures()).toMatchSnapshot();
+  });
+  it('should create an ActionListFeature from a CAMPAIGN_ITEMS algorithm', async () => {
+    const result = await Feature.createActionListFeature({
+      algorithms: [
+        {
+          type: 'CAMPAIGN_ITEMS',
+        },
+      ],
+      title: 'Test Featured Item',
+      subtitle: "It's featured!",
+    });
+
+    expect(await expandResult(result)).toMatchSnapshot();
+    expect(
+      context.dataSources.ContentItem.getCursorByParentContentItemId.mock.calls
+    ).toMatchSnapshot();
+    expect(
+      context.dataSources.ContentItem.byContentChannelIds.mock.calls
+    ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## DESCRIPTION

Fixes the custom `order` code by only sorting by `order` if we actually are requesting to sort by `order`. Fixes cases where we want to sort by other attributes, like for the campaign item. 

![image](https://user-images.githubusercontent.com/1637694/98167309-dddc1000-1eb6-11eb-8e24-185bba3d353b.png)

### What does this PR do, or why is it needed?

### How do I test this PR?

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings
- [ ] Upload Screenshots/GIF(s) if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
