### PR TITLE
Typo in channel name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -300,14 +300,14 @@ DISCOVER_FEATURES:
       relatedNode:
         __typename: ContentChannel
         id: 18
-        name: Articles
+        name: Studies
   - algorithms:
       - type: CONTENT_CHANNEL
         arguments:
           contentChannelId: 16
           limit: 3
     type: HorizontalCardList
-    subtitle: Studies
+    subtitle: Articles
     primaryAction:
       action: OPEN_CHANNEL
       title: 'View All'
@@ -342,7 +342,7 @@ DISCOVER_FEATURES:
       relatedNode:
         __typename: ContentChannel
         id: 28
-        name: Stories        
+        name: Stories
 
 # Default mapping of field types -> ids. There's probably no reason to edit this.
 ROCK_CONSTANTS:


### PR DESCRIPTION
## DESCRIPTION

Fixes a typo where Articles were being referred to as Studies in the Discover Feed. 

![image](https://user-images.githubusercontent.com/1637694/98594242-620d0980-22a2-11eb-8fb5-25791cf03405.png)


### What does this PR do, or why is it needed?

### How do I test this PR?

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings
- [ ] Upload Screenshots/GIF(s) if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

---

> The purpose of a PR Review is to _improve the quality of the software._
