### PR TITLE
fix: broken forgot password link

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,7 @@ APP:
   JOBS_USERNAME: ${JOBS_USERNAME}
   JOBS_PASSWORD: ${JOBS_PASSWORD}
   FLAG_LIMIT: 2
+  FORGOT_PASSWORD_URL: https://rock.newspring.cc/page/56
 DATABASE:
   URL: ${DATABASE_URL}
 BUGSNAG:
@@ -27,7 +28,6 @@ ROCK:
   API_TOKEN: ${ROCK_TOKEN}
   IMAGE_URL: https://s3.amazonaws.com
   SHARE_URL: https://newspring.cc
-  FORGOT_PASSWORD_URL: https://rock.newspring.cc/page/56
   # This should match the timezone of the Rock server
   TIMEZONE: 'America/New_York'
   USE_PLUGIN: true

--- a/src/server.js
+++ b/src/server.js
@@ -43,7 +43,7 @@ const cacheOptions = isDev
       },
     };
 
-const { ENGINE } = ApollosConfig;
+const { APP, ROCK, ENGINE } = ApollosConfig;
 
 const apolloServer = new ApolloServer({
   typeDefs: schema,
@@ -71,6 +71,11 @@ const apolloServer = new ApolloServer({
 });
 
 const app = express();
+
+// password reset
+app.get('/forgot-password', (req, res) => {
+  res.redirect(APP.FORGOT_PASSWORD_URL || `${ROCK.URL}/page/56`);
+});
 
 applyServerMiddleware({ app, dataSources, context });
 setupJobs({ app, dataSources, context });


### PR DESCRIPTION
@redreceipt I tried adding this newish code to fix the linking, but I'm not getting the expected redirect when I navigate to `localhost:4000/forgot-password`. I tried logging within this `app.get` function, but not getting any response there either. Do you see what other setup I'm missing to get this working?